### PR TITLE
Add FQDNS to VMs

### DIFF
--- a/parts/vmresources.t
+++ b/parts/vmresources.t
@@ -3,7 +3,10 @@
       "location": "[parameters('location')]",
       "name": "[variables('{{.Name}}PublicIPAddressName')]",
       "properties": {
-        "publicIPAllocationMethod": "Dynamic"
+        "publicIPAllocationMethod": "Dynamic",
+        "dnsSettings": {
+          "domainNameLabel": "{{.Name}}"
+        }
       },
       "type": "Microsoft.Network/publicIPAddresses"
     },


### PR DESCRIPTION
I tried to build the project, but I hit some problems I could not fix:

```
go generate  -v `glide novendor | xargs go list`
can't load package: package _/home/v-amcham/oe-engine/cmd: cannot find package "_/home/v-amcham/oe-engine/cmd" in any of:
	/usr/local/go/src/_/home/v-amcham/oe-engine/cmd (from $GOROOT)
	/home/v-amcham/go/src/_/home/v-amcham/oe-engine/cmd (from $GOPATH)
can't load package: package _/home/v-amcham/oe-engine/pkg/api: cannot find package "_/home/v-amcham/oe-engine/pkg/api" in any of:
	/usr/local/go/src/_/home/v-amcham/oe-engine/pkg/api (from $GOROOT)
...
```

I did test this manually by editing the resulting ARM templates, running a deployment, and checking that the VM was created with the right FQDNS.