### PR TITLE
Small fix for the parts/windowsProvision.ps1

### DIFF
--- a/parts/windowsProvision.ps1
+++ b/parts/windowsProvision.ps1
@@ -306,7 +306,7 @@ function Install-Git {
     Install-Tool -InstallerPath $PACKAGES["git"]["local_file"] `
                  -InstallDirectory $installDir `
                  -ArgumentList @("/SILENT") `
-                 -EnvironmentPath @("$installDir\cmd", "$installDir\bin", "installDir\mingw64\bin")
+                 -EnvironmentPath @("$installDir\cmd", "$installDir\bin", "$installDir\mingw64\bin")
 
 }
 


### PR DESCRIPTION
The PowerShell variable usage lacked `$` sign.