### PR TITLE
 Add logs to provision failing and disable remote_attestation test

### DIFF
--- a/parts/provision.sh
+++ b/parts/provision.sh
@@ -12,6 +12,12 @@ cd /opt/azure/acc/
 
 OE_PKG_BASE="PACKAGE_BASE_URL"
 
+readonly LOG_FILE="/opt/azure/acc/deployment.log"
+set -x
+touch $LOG_FILE
+exec 1>$LOG_FILE
+exec 2>&1
+
 function error_exit() {
   echo $1
   echo "failed" > /opt/azure/acc/completed

--- a/parts/validate.sh
+++ b/parts/validate.sh
@@ -36,6 +36,7 @@ else
 fi
 cd $tempdir/samples
 
+export OE_LOG_LEVEL=INFO
 find . -maxdepth 1 -type d -not -path "*remote_attestation" -not -path "." -exec sh -c "echo Running {}; cd {} && make && make run" \;
 
 echo "open-enclave validation completed $msg"

--- a/parts/validate.sh
+++ b/parts/validate.sh
@@ -18,6 +18,7 @@ set -o errexit
 
 # set logfile
 readonly LOG_FILE="/opt/azure/acc/validation.log"
+set -x
 touch $LOG_FILE
 exec 1>$LOG_FILE
 exec 2>&1
@@ -36,11 +37,5 @@ fi
 cd $tempdir/samples
 
 find . -maxdepth 1 -type d -not -path "*remote_attestation" -not -path "." -exec sh -c "echo Running {}; cd {} && make && make run" \;
-
-# build and run remote_attestation sample. Ignore run-time errors
-cd remote_attestation
-msg=""
-make
-make run || msg="WITH ERRORS"
 
 echo "open-enclave validation completed $msg"

--- a/parts/vars.t
+++ b/parts/vars.t
@@ -73,4 +73,4 @@
     ],
     "securityRules": "[if(equals(parameters('osImageName'), 'WindowsServer_2016'), variables('windowsSecurityRules'), variables('linuxSecurityRules'))]",
     "diagnosticsStorageAction": "[if(equals(parameters('bootDiagnostics'), 'disable'), 'nop', parameters('diagnosticsStorageAccountNewOrExisting'))]",
-    "linuxExtCommand": "[if(equals(parameters('oeSDKIncluded'), 'yes'), '/bin/bash -c \"secs=600; SECONDS=0; while (( SECONDS < secs )); do if [ -e /opt/azure/acc/completed ]; then if [ $(cat /opt/azure/acc/completed) == ok ]; then /opt/azure/acc/validate.sh; exit $? ; else echo provision failed; exit 1; fi; fi; sleep 20; done; echo validation timeout; exit 1; \"', '/bin/bash -c \"exit 0\"')]"
+    "linuxExtCommand": "[if(equals(parameters('oeSDKIncluded'), 'yes'), '/bin/bash -c \"secs=600; SECONDS=0; while (( SECONDS < secs )); do if [ -e /opt/azure/acc/completed ]; then if [ $(cat /opt/azure/acc/completed) == ok ]; then /opt/azure/acc/validate.sh; exit $? ; else echo provision failed; cat /opt/azure/acc/deployment.log; exit 1; fi; fi; sleep 20; done; echo validation timeout; exit 1; \"', '/bin/bash -c \"exit 0\"')]"


### PR DESCRIPTION
This addresses two newly opened issues regarding ACC deployments.

1. This sets the bash "-x" flag to produce logs for both deployment and validate scripts. It stores the log messages in .log files in /opt/azure/acc
2. This entirely removes the remote_attestation test from being run in the validate script. Previously, the validate script was running the remote_attestation test and *supposedly* ignoring errors from the "make run" command by using the bash logical OR construct "||" to avoid the "set -e" flag from causing the script to error. However, in practice, we noticed a deployment failure once when the remote_attestation test failed. Since we are supposed to ignore the error from the remote_attestation test in general, we might as well simply not even run the test.