### PR TITLE
Fix regression with the data disks implementation

### DIFF
--- a/parts/resources.t
+++ b/parts/resources.t
@@ -30,7 +30,6 @@
       "location": "[parameters('location')]",
       "properties": {
         "storageProfile": {
-          {{GetDataDisks .}}
           "osDisk": {
             "osType": "Windows",
             "osState": "Generalized",
@@ -49,7 +48,6 @@
       "location": "[parameters('location')]",
       "properties": {
         "storageProfile": {
-          {{GetDataDisks .}}
           "osDisk": {
             "osType": "Linux",
             "osState": "Generalized",
@@ -82,4 +80,3 @@
       },
       "type": "Microsoft.Network/virtualNetworks"
     }
-    


### PR DESCRIPTION
Currently, the data disks implementation doesn't work when used with the custom VHD scenario.

Upon investigation, we found out that the `{{GetDataDisks .}}` is not necessary in the `parts/resources.t` template, and removing it solves the regression.

Fixes https://github.com/microsoft/oe-engine/issues/46