### PR TITLE
Dxs_v3 VMs work fine with the existing templates

### DIFF
--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -49,6 +49,12 @@ var AllowedLocations = []string{
 var AllowedVMSizes = []string{
 	"Standard_DC2s",
 	"Standard_DC4s",
+	"Standard_D2s_v3",
+	"Standard_D4s_v3",
+	"Standard_D8s_v3",
+	"Standard_D16s_v3",
+	"Standard_D32s_v3",
+	"Standard_D64s_v3",
 }
 
 // AllowedOsDiskTypes provides supported OS disk types


### PR DESCRIPTION
@johnkord as discussed previously, we've tried this out, and it works great. This is really helpful when testing, because we don't want to use SGX VMs for clients, and it's super convenient to have everything in one file, on the same vNet, rather than need to do bits and pieces in different ways.

I'm happy to be on the hook for any maintenance related to this of course.