### PR TITLE
Add support to Enable WinRM for Ansible

### DIFF
--- a/parts/vmparams.t
+++ b/parts/vmparams.t
@@ -1,4 +1,4 @@
-    
+
     "{{.Name}}VMSize": {
       "type": "string",
       {{GetAllowedVMSizes}}
@@ -32,6 +32,17 @@
       ],
       "metadata": {
         "description": "Flag to provision vanilla VM or install OE SDK."
+      }
+    },
+    "{{.Name}}EnableWinRM": {
+      "type": "string",
+      "defaultValue": "false",
+      "allowedValues": [
+        "false",
+        "true"
+      ],
+      "metadata": {
+        "description": "Flag to enable WinRM for ansible."
       }
     },
     "{{.Name}}HasDNSName": {

--- a/parts/windowsProvision.ps1
+++ b/parts/windowsProvision.ps1
@@ -4,10 +4,11 @@
 $ErrorActionPreference = "Stop"
 
 $IS_VANILLA = "IS_VANILLA_VM"
+$ENABLE_WINRM = "ENABLE_WINRM_VM"
 $AZUREDATA_DIRECTORY = Join-Path ${env:SystemDrive} "AzureData"
 $AZUREDATA_BIN_DIRECTORY = Join-Path $AZUREDATA_DIRECTORY "bin"
 $PACKAGES_DIRECTORY = Join-Path $env:TEMP "packages"
-$PACKAGES_NAMES_VANILLA = @("7z", "git", "openssh")
+$PACKAGES_NAMES_VANILLA = @("7z", "git", "openssh", "RemotingforAnsible")
 $PACKAGES = @{
     "openssh" = @{
         "url" = "https://github.com/PowerShell/Win32-OpenSSH/releases/download/v7.7.2.0p1-Beta/OpenSSH-Win64.zip"
@@ -18,7 +19,10 @@ $PACKAGES = @{
         "local_file" = Join-Path $PACKAGES_DIRECTORY "azure.dcap.windows.0.0.2.nupkg"
         "renamed_file" = Join-Path $PACKAGES_DIRECTORY "azure.dcap.windows.0.0.2.zip"
     }
-
+    "RemotingforAnsible" = @{
+        "url" = "https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1"
+        "local_file" = Join-Path $PACKAGES_DIRECTORY "ConfigureRemotingForAnsible.ps1"
+    }
     "git" = @{
         "url" = "https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/Git-2.19.1-64-bit.exe"
         "local_file" = Join-Path $PACKAGES_DIRECTORY "git-2.19.1-64-bit.exe"
@@ -443,6 +447,11 @@ try {
     Install-Git
     Install-7Zip
     Install-OpenSSH
+
+    if ($ENABLE_WINRM -eq "true") {
+        Write-Output "Enable WinRM for Ansible"
+        powershell.exe -ExecutionPolicy ByPass -File $PACKAGES["RemotingforAnsible"]["local_file"] -ForceNewSSLCert
+    }
 
     if ($IS_VANILLA -eq "true") {
         Write-Output "Skipping Open Enclave installation."

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -19,6 +19,7 @@ type VMProfile struct {
 	VMSize      string `json:"vmSize"`
 	Ports       []int  `json:"ports,omitempty" validate:"dive,min=1,max=65535"`
 	IsVanilla   bool   `json:"isVanilla"`
+	EnableWinRM bool   `json:"enableWinRM"`
 	HasDNSName  bool   `json:"hasDNSName"`
 }
 

--- a/pkg/engine/params.go
+++ b/pkg/engine/params.go
@@ -20,6 +20,7 @@ func getParameters(cs *api.OpenEnclave, generatorCode string) (paramsMap, error)
 		addValue(parametersMap, fmt.Sprintf("%sVMSize", vm.Name), vm.VMSize)
 		addValue(parametersMap, fmt.Sprintf("%sOSType", vm.Name), vm.OSType)
 		addValue(parametersMap, fmt.Sprintf("%sIsVanilla", vm.Name), strconv.FormatBool(vm.IsVanilla))
+		addValue(parametersMap, fmt.Sprintf("%sEnableWinRM", vm.Name), strconv.FormatBool(vm.EnableWinRM))
 		addValue(parametersMap, fmt.Sprintf("%sHasDNSName", vm.Name), strconv.FormatBool(vm.HasDNSName))
 		if len(vm.OSDiskType) > 0 {
 			addValue(parametersMap, fmt.Sprintf("%sOSDiskType", vm.Name), vm.OSDiskType)

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -165,6 +165,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.OpenEnclave) template.Fun
 			csStr := string(b)
 			csStr = strings.Replace(csStr, "SSH_PUB_KEY", cs.Properties.WindowsProfile.SSHPubKey, -1)
 			csStr = strings.Replace(csStr, "IS_VANILLA_VM", strconv.FormatBool(vm.IsVanilla), -1)
+			csStr = strings.Replace(csStr, "ENABLE_WINRM_VM", strconv.FormatBool(vm.EnableWinRM), -1)
 			return getBase64CustomScriptFromStr(csStr)
 		},
 		"GetAllowedVMSizes": func() string {


### PR DESCRIPTION
Add a new toggle to oe-engine template called enableWinRM 

When this is set to true , it will enable WinRM support for Ansible

fixes #52