### PR TITLE
Add support for DC8_v2

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -67,7 +67,7 @@ Set the default subscription for your account if it has multiple active subscrip
 ```sh
 az account set --subscription <subscription id>
 ```
-Create resource group. Currently SGX VMs are only supported in `eastus` and `westeurope` regions.
+Create resource group. Currently SGX VMs are only supported in `eastus`, `westeurope` and `uksouth` regions.
 ```sh
 az group create -l eastus -n <resource group name>
 ```

--- a/docs/examples/oe-dc8.json
+++ b/docs/examples/oe-dc8.json
@@ -1,0 +1,28 @@
+{
+  "properties": {
+    "vmProfiles": [
+      {
+        "name": "acclnx",
+        "osType": "Linux",
+        "osDiskType": "StandardSSD_LRS",
+	"vmSize": "Standard_DC8_v2",
+        "ports": [22],
+        "isVanilla": true
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "sshPublicKeys": [
+        {
+          "keyData": "ssh-rsa AAAA..."
+        }
+      ],
+      "osImage": {
+        "publisher": "Canonical",
+        "offer": "UbuntuServer",
+        "sku": "18_04-lts-gen2",
+        "version": "latest"
+      }
+    }
+  }
+}

--- a/docs/properties.md
+++ b/docs/properties.md
@@ -36,6 +36,9 @@ Specifies VM compute characteristics
 * Values:
     * `Standard_DC2s`
     * `Standard_DC4s`
+    * `Standard_DC1s_v2`
+    * `Standard_DC2s_v2`
+    * `Standard_DC4s_v2`
     * `Standard_DC8_v2`
 
 Refer to the [VM sizes in Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes) for more details.
@@ -119,4 +122,4 @@ Alternatively, you can specify image source URL.
 * Path: `properties/{linux|windows}Profile/osImage/url`
 * Value: string
 
-Note that newer VMs, such as `Standard_DC8_v2` sizes, require a `gen2` image.
+Note that the _v2 version of the DC series VMs require a gen2 image of the OS. For example, in the case of Ubuntu, "18_04-lts-gen2".

--- a/docs/properties.md
+++ b/docs/properties.md
@@ -27,6 +27,8 @@ Specifies OS disk characteristics.
     * `StandardSSD_LRS` - Standard SSD
     * `Standard_LRS` - Standard HDD
 
+Note that VM sizes ending in `s` support Premium SSD storage. Those that do not end in `s`, such as `Standard_DC8_v2` only support Standard storage.
+
 ### VM compute power
 Specifies VM compute characteristics
 
@@ -34,6 +36,7 @@ Specifies VM compute characteristics
 * Values:
     * `Standard_DC2s`
     * `Standard_DC4s`
+    * `Standard_DC8_v2`
 
 Refer to the [VM sizes in Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes) for more details.
 
@@ -115,3 +118,5 @@ Alternatively, you can specify image source URL.
 
 * Path: `properties/{linux|windows}Profile/osImage/url`
 * Value: string
+
+Note that newer VMs, such as `Standard_DC8_v2` sizes, require a `gen2` image.

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -43,12 +43,14 @@ var DefaultWindowsImage = OSImage{
 var AllowedLocations = []string{
 	"eastus",
 	"westeurope",
+	"uksouth"
 }
 
 // AllowedVMSizes provides supported VM sizes
 var AllowedVMSizes = []string{
 	"Standard_DC2s",
 	"Standard_DC4s",
+	"Standard_DC8_v2",
 	"Standard_D2s_v3",
 	"Standard_D4s_v3",
 	"Standard_D8s_v3",

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -43,7 +43,7 @@ var DefaultWindowsImage = OSImage{
 var AllowedLocations = []string{
 	"eastus",
 	"westeurope",
-	"uksouth"
+	"uksouth",
 }
 
 // AllowedVMSizes provides supported VM sizes

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -50,6 +50,9 @@ var AllowedLocations = []string{
 var AllowedVMSizes = []string{
 	"Standard_DC2s",
 	"Standard_DC4s",
+	"Standard_DC1s_v2",
+	"Standard_DC2s_v2",
+	"Standard_DC4s_v2",
 	"Standard_DC8_v2",
 	"Standard_D2s_v3",
 	"Standard_D4s_v3",


### PR DESCRIPTION
Adding supporting for the newly available VMs in uksouth, Standard_DC8_v2.

It's worth noting that they can only be provisioned with osDiskType: "StandardSSD_LRS", since they do not support premium storage, and with the "18_04-lts-gen2" image, since "18.04-LTS" is gen1 and those VMs only support gen2.

I've tested this against our subscription.