### PR TITLE
[CI/CD] Fix Jenkins CI pipelines

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,8 +40,8 @@ node("nonSGX") {
             }
         }
     } catch (err) {
-        echo err.getMessage
         currentBuild.result = 'FAILURE'
+        throw err
     } finally {
         archiveArtifacts artifacts: 'gopath/src/github.com/Microsoft/oe-engine/test/agent_logs/**/*.log', fingerprint: true, allowEmptyArchive: true
     }

--- a/test/acc-deploy-test.groovy
+++ b/test/acc-deploy-test.groovy
@@ -27,8 +27,8 @@ node("nonSGX") {
             }
         }
     } catch (err) {
-        echo err.getMessage
         currentBuild.result = 'FAILURE'
+        throw err
     } finally {
         archiveArtifacts artifacts: 'gopath/src/github.com/Microsoft/oe-engine/work/*.log', fingerprint: true, allowEmptyArchive: true
     }


### PR DESCRIPTION
Sometimes, the following message is given by the Jenkins CI:
```
No such field found: field hudson.AbortException getMessage
```

Thus, if an error is caught, we set failure job status, and
re-throw the error.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>