### PR TITLE
[CI/CD] Add missing Docker registry info

### DIFF
--- a/test/static-template/Jenkinsfile
+++ b/test/static-template/Jenkinsfile
@@ -4,6 +4,8 @@ pipeline {
   agent {
     docker {
       image 'ubuntu18.04-dev'
+      registryUrl 'https://oejenkinscidockerregistry.azurecr.io'
+      registryCredentialsId 'oejenkinscidockerregistry'
       label 'nonSGX'
     }
   }


### PR DESCRIPTION
The `ubuntu18.04-dev` image comes from our private Azure Docker registry, and we need to make sure that the CI can properly login to that.