### PR TITLE
Update download links for sgx driver in provision.sh

### DIFF
--- a/parts/provision.sh
+++ b/parts/provision.sh
@@ -30,11 +30,11 @@ function setup_ubuntu() {
 
   case $version in
     "18.04")
-      sgx_driver_url="https://download.01.org/intel-sgx/dcap-1.2/linux/dcap_installers/ubuntuServer18.04/sgx_linux_x64_driver_1.12_c110012.bin"
+      sgx_driver_url="https://download.01.org/intel-sgx/latest/dcap-latest/linux/distro/ubuntuServer18.04/sgx_linux_x64_driver_1.21.bin"
       PACKAGES="$PACKAGES curl libcurl4 libprotobuf10"
       ;;
     "16.04")
-      sgx_driver_url="https://download.01.org/intel-sgx/dcap-1.2/linux/dcap_installers/ubuntuServer16.04/sgx_linux_x64_driver_1.12_c110012.bin"
+      sgx_driver_url="https://download.01.org/intel-sgx/latest/dcap-latest/linux/distro/ubuntuServer16.04/sgx_linux_x64_driver_1.21.bin"
       PACKAGES="$PACKAGES libcurl3 libprotobuf9v5"
       ;;
     "*")


### PR DESCRIPTION
The current download links are very out of date. The current driver is 1.21, while we are pulling down 1.12.  